### PR TITLE
Fix docker-compose env keyword

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,7 @@ services:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    env:
+    environment:
       - VITE_API_BASE_URL=host.docker.internal:8001
     ports:
       - "8080:80"


### PR DESCRIPTION
## Summary
- use `environment:` instead of `env:` for the web UI service

## Testing
- `make -C backend test`
- `npm run lint` in `frontend`
- `docker compose up -d` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686235576d708332a07e58f0a06accae