### PR TITLE
Fix quick start frontend command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Backend: (requires GO)
 - Open a terminal
 - `cd backend && STORAGE=memory go run cmd/threadwell/main.go`
 
-Frontend: (requires Nodes) 
+Frontend: (requires Nodes)
 - Open a terminal
-- `cd frontend && npm ci && node run dev`
+- `cd frontend && npm ci && npm run dev`
 
 
 ---


### PR DESCRIPTION
## Summary
- fix quick-start command in README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6862399a6154833297053392812efbe3