### PR TITLE
Fix: Vite API base URL handling

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     environment:
-      - VITE_API_BASE_URL=host.docker.internal:8001
+      - VITE_API_BASE_URL=http://host.docker.internal:8001
     ports:
       - "8080:80"
     restart: unless-stopped

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react'
 import tsconfigPaths from 'vite-tsconfig-paths'
 import tailwindcss from '@tailwindcss/vite'
 
+const API_BASE_URL = process.env.VITE_API_BASE_URL || 'http://localhost:8001'
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tsconfigPaths(), tailwindcss()],
@@ -10,14 +12,11 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': {
-        target: 'http://localhost:8001',
+        target: API_BASE_URL,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, '/api'), // optional, adjust if needed
       },
     },
   },
 
-  define: {
-    'import.meta.env.VITE_API_BASE_URL': JSON.stringify('http://localhost:8001'),
-  },
 })


### PR DESCRIPTION
## Summary
- update compose value with `http://` scheme
- read `VITE_API_BASE_URL` in Vite config instead of hardcoding

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68623a5efdc48332a2a606ffbb29dbe7