### PR TITLE
Improve backend test coverage

### DIFF
--- a/backend/api/handlers_test.go
+++ b/backend/api/handlers_test.go
@@ -265,3 +265,29 @@ func TestMoveSubtree(t *testing.T) {
 		t.Errorf("expected thread_id in response")
 	}
 }
+
+func TestThreadPatch(t *testing.T) {
+	srv := newTestServer()
+	defer srv.Close()
+
+	// create thread
+	threadBody := `{"title":"before"}`
+	res, err := http.Post(srv.URL+"/api/threads", "application/json", bytes.NewBufferString(threadBody))
+	require.NoError(t, err)
+	var tCreated models.Thread
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&tCreated))
+	res.Body.Close()
+
+	// patch title
+	patchBody := `{"title":"after"}`
+	req, _ := http.NewRequest(http.MethodPatch, srv.URL+"/api/threads/"+tCreated.ID, strings.NewReader(patchBody))
+	req.Header.Set("Content-Type", "application/json")
+	res, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	var updated models.Thread
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&updated))
+	res.Body.Close()
+	require.Equal(t, "after", updated.Title)
+}

--- a/backend/api/helpers_test.go
+++ b/backend/api/helpers_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWriteJSONAndError(t *testing.T) {
+	rr := httptest.NewRecorder()
+	WriteJSON(rr, http.StatusCreated, map[string]string{"ok": "true"})
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %s", ct)
+	}
+	expected := "{\"ok\":\"true\"}\n"
+	if rr.Body.String() != expected {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+
+	rr = httptest.NewRecorder()
+	WriteError(rr, http.StatusBadRequest, "bad")
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d", http.StatusBadRequest, rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "bad") {
+		t.Fatalf("expected error message in body")
+	}
+}

--- a/backend/config/config_test.go
+++ b/backend/config/config_test.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLoadReadsEnv(t *testing.T) {
+	os.Setenv("STORAGE_TYPE", "sqlite")
+	os.Setenv("STORAGE_PATH", "/tmp/test.db")
+	defer os.Unsetenv("STORAGE_TYPE")
+	defer os.Unsetenv("STORAGE_PATH")
+
+	cfg := Load()
+	if cfg.Storage.Type != "sqlite" {
+		t.Fatalf("expected storage type sqlite, got %s", cfg.Storage.Type)
+	}
+	if cfg.Storage.Path != "/tmp/test.db" {
+		t.Fatalf("expected storage path /tmp/test.db, got %s", cfg.Storage.Path)
+	}
+}


### PR DESCRIPTION
## Summary
- add config.Load coverage
- add helper WriteJSON/WriteError tests
- add API thread patch test

## Testing
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_68638609d7e4833293f9169f0d717d6d