### PR TITLE
Add ChatThread and MessageInput tests

### DIFF
--- a/frontend/src/__tests__/ChatThread.test.tsx
+++ b/frontend/src/__tests__/ChatThread.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import ChatThread from '../components/Chat/ChatThread';
+import type { ChatMessage } from '@/types';
+
+const messages: ChatMessage[] = [
+  { id: '1', thread_id: 't1', role: 'user', content: 'Hello', timestamp: 0 },
+  { id: '2', thread_id: 't1', role: 'assistant', parent_id: '1', content: 'Hi there', timestamp: 1 },
+  { id: '3', thread_id: 't1', role: 'user', parent_id: '2', content: 'How are you?', timestamp: 2 }
+];
+
+const noop = () => {};
+
+describe('ChatThread', () => {
+  it('renders threaded messages', () => {
+    render(<ChatThread messages={messages} onReply={noop} onMoveToChat={noop} activeThreadId={null} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hi there')).toBeInTheDocument();
+    expect(screen.getByText('How are you?')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/MessageInput.test.tsx
+++ b/frontend/src/__tests__/MessageInput.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import MessageInput from '../components/Chat/MessageInput';
+
+const noop = () => {};
+
+describe('MessageInput', () => {
+  it('submits message on Enter key', () => {
+    const handleSend = vi.fn();
+    render(
+      <MessageInput onSend={handleSend} activeThreadId={null} clearThread={noop} />
+    );
+    const textarea = screen.getByPlaceholderText('Type a message…');
+    fireEvent.change(textarea, { target: { value: 'Hello' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', code: 'Enter', charCode: 13 });
+    expect(handleSend).toHaveBeenCalledWith('Hello');
+  });
+
+  it('shows disabled state', () => {
+    render(
+      <MessageInput onSend={noop} activeThreadId={null} clearThread={noop} disabled />
+    );
+    const textarea = screen.getByPlaceholderText('Processing...') as HTMLTextAreaElement;
+    expect(textarea.disabled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for ChatThread tree rendering
- add tests for MessageInput submit/disabled states

## Testing
- `cd frontend && npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6882abba08d48332a090590005a1f8c1