### PR TITLE
Remove overflow hidden from main

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,7 +82,7 @@ const App: React.FC = () => {
 
 
             {/* --- Main Content UI --- */}
-            <main className="flex flex-col flex-1 overflow-hidden bg-background">
+            <main className="flex flex-col flex-1 overflow-visible bg-background">
                 {currentThreadId && currentThread ? (
                     <>
                         <header className="p-4 border-b flex-shrink-0">


### PR DESCRIPTION
## Summary
- show full chat thread content by letting `<main>` overflow

## Testing
- `npm test --silent` (vitest)
- `npx vitest run --silent`


------
https://chatgpt.com/codex/tasks/task_e_688323c07ccc83329d447c49b15eddc9